### PR TITLE
[sapphire#2] Adding Monero Stats fetching 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "apollo-server": "^2.9.9",
     "apollo-server-express": "^2.9.9",
     "app-module-path": "^2.2.0",
+    "axios": "^0.19.0",
     "bcrypt": "^3.0.6",
     "big-integer": "^1.6.44",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
This PR is part of 

Ticket | Title
---|---
#2  | Create proper hashrate calculation and Myriade Credit assignment

## Description

This PR will fetch stats from the public monero API.

## Implementation / Approach

This will use Axios to make a GET request to the public monero API at `http://moneroblocks.info/api/get_stats/`

## Checklist

- [ ] ~Appropriate Unit test coverage~ (N/A Pre-Alpha)
- [x] Manual top-hatting has been performed
- [ ] ~This PR is linted, tested and follows the best practices of the organization~