### PR TITLE
Credit event service bug fix - ALPHA-17

### DIFF
--- a/src/routes/credit.event.router.js
+++ b/src/routes/credit.event.router.js
@@ -23,7 +23,7 @@ router.post(
       const minerId = req.body.minerId
       const amount = req.body.amount
 
-      const txSucceeds = CreditService.create(minerId, amount, req.body.lockType, req.body.comments)
+      const txSucceeds = CreditEventService.create(minerId, amount, req.body.lockType, req.body.comments)
       if (!txSucceeds) {
         return res.status(406).send({
           error: `Insufficient funds for purchase amount ${amount}`

--- a/test/services/credit.event.service.test.js
+++ b/test/services/credit.event.service.test.js
@@ -14,7 +14,7 @@ require("chai")
     .use(require("chai-string"))
     .should();
 
-describe.only("Credit Event Service Unit Tests", () => {
+describe("Credit Event Service Unit Tests", () => {
     before("Await DB", () => {
         return testing.dbReady;
     });
@@ -63,8 +63,6 @@ describe.only("Credit Event Service Unit Tests", () => {
         const participants = await CreditEventService.getUniqueParticipants(eventInfo.id)
         const expected = MinerTestingHelper.sampleMiners.map(miner => miner.id.toString()).sort()
         participants.sort().should.eql(expected)
-
-
     })
 
 });


### PR DESCRIPTION
Ticket | Title
---|---
ALPHA-17 | Buying credit event, 500 error

## Description

The wrong var name was being used (creditService instead of creditEventService), so it was throwing 500 errors.

## Implementation / Approach

Fixed the naming

## Checklist

- [ ] Appropriate Unit test coverage
- [ ] Manual top-hatting has been performed
- [ ] This PR is linted, tested and follows the best practices of the organization